### PR TITLE
bakeCookies handles RFC6265

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,11 +20,13 @@
     "purescript-maybe": "^4.0.0",
     "purescript-foldable-traversable": "^4.0.1",
     "purescript-strings": "^4.0.0",
-    "purescript-js-date": "^6.0.0"
+    "purescript-js-date": "^6.0.0",
+    "purescript-parsing": "^5.0.2"
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",
     "purescript-debug": "^4.0.0",
-    "purescript-test-unit": "^14.0.0"
+    "purescript-test-unit": "^14.0.0",
+    "purescript-quickcheck": "^5.0.0"
   }
 }

--- a/src/Browser/Cookies/Internal.purs
+++ b/src/Browser/Cookies/Internal.purs
@@ -55,12 +55,11 @@ val = PC.try (quoted rfc2625) <|> rfc2625
   where quoted = PC.between (PS.string "\"") (PS.string "\"")
         rfc2625 = SCU.fromCharArray
                   <$> Array.some (PT.alphaNum <|> special)
-        special = PC.choice
-                  (PS.char
-                   <$> ['!', '#', '$', '%', '&', '\'', '(', ')', '*'
-                       , '+', '-', '.', '/', ':', '<', '=', '>', '?'
-                       , '@', '[', ']', '^', '_', '`', '{', '|', '}'
-                       , '~']) 
+        special = PC.choice $ PS.char
+                  <$> ['!', '#', '$', '%', '&', '\'', '(', ')', '*'
+                      , '+', '-', '.', '/', ':', '<', '=', '>', '?'
+                      , '@', '[', ']', '^', '_', '`', '{', '|', '}'
+                      , '~']
                   
 
 

--- a/src/Browser/Cookies/Internal.purs
+++ b/src/Browser/Cookies/Internal.purs
@@ -2,12 +2,68 @@
 module Browser.Cookies.Internal (bakeCookies, findCookie) where
 
 import Prelude
+
+import Browser.Cookies.Data (Cookie(..))
+
+import Control.Alternative ((<|>))
+
+import Data.Array (catMaybes)
+import Data.Array as Array
+import Data.Either (Either(..))
+import Data.List as List
 import Data.Maybe (Maybe(..))
 import Data.String.Common (split, trim)
+import Data.String.CodeUnits as SCU
 import Data.String.Pattern (Pattern(..))
-import Data.Array (catMaybes)
 import Data.Foldable (class Foldable, find)
-import Browser.Cookies.Data (Cookie(..))
+
+import Text.Parsing.Parser (Parser, runParser)
+import Text.Parsing.Parser as Parser
+import Text.Parsing.Parser.Combinators as PC
+import Text.Parsing.Parser.String (skipSpaces)
+import Text.Parsing.Parser.String as PS
+import Text.Parsing.Parser.Token as PT
+
+
+-- * Parsing
+data Pair = Pair String String
+
+instance showPair :: Show Pair where
+  show (Pair k v) = "Pair " <> k <> " " <> v
+
+pairs :: Parser String (Array Pair)
+pairs = Array.fromFoldable <$> PC.sepBy pair (PS.string ";")
+
+pair :: Parser String Pair
+pair = do
+  k <- key
+  void $ PS.char '='
+  v <- val
+  pure $ Pair k v
+
+key :: Parser String String
+key = SCU.fromCharArray
+      <$> Array.some (PT.alphaNum <|> special)
+  where
+    special = PC.choice $ PS.char
+              <$> ['!', '#', '$', '%', '&', '\''
+                  ,'*', '+', '-', '.', '^', '_'
+                  ,'`', '|', '~']
+
+val :: Parser String String
+val = PC.try (quoted rfc2625) <|> rfc2625
+  where quoted = PC.between (PS.string "\"") (PS.string "\"")
+        rfc2625 = SCU.fromCharArray
+                  <$> Array.some (PT.alphaNum <|> special)
+        special = PC.choice
+                  (PS.char
+                   <$> ['!', '#', '$', '%', '&', '\'', '(', ')', '*'
+                       , '+', '-', '.', '/', ':', '<', '=', '>', '?'
+                       , '@', '[', ']', '^', '_', '`', '{', '|', '}'
+                       , '~']) 
+                  
+
+
 
 splitOnSemicolon :: String -> Array String 
 splitOnSemicolon str = trim <$> split (Pattern ";") str
@@ -15,12 +71,19 @@ splitOnSemicolon str = trim <$> split (Pattern ";") str
 splitOnEquals :: String -> Array String
 splitOnEquals str = trim <$> split (Pattern "=") str
 
+-- bakeCookies :: String -> Array Cookie
+-- bakeCookies str = catMaybes $ arrToCookie <$> splitOnEquals <$> splitOnSemicolon str
+--                     where
+--                         arrToCookie :: Array String -> Maybe Cookie
+--                         arrToCookie [key,value] = Just $ Cookie { key, value }
+--                         arrToCookie _ = Nothing
+
 bakeCookies :: String -> Array Cookie
-bakeCookies str = catMaybes $ arrToCookie <$> splitOnEquals <$> splitOnSemicolon str
-                    where
-                        arrToCookie :: Array String -> Maybe Cookie
-                        arrToCookie [key,value] = Just $ Cookie { key, value }
-                        arrToCookie _ = Nothing
+bakeCookies str = case runParser str pairs of
+  Left e -> []
+  Right cs -> map pairToCookie cs
+  where
+    pairToCookie (Pair key value) = Cookie {key, value}
 
 findCookie :: forall f. Foldable f => String -> f Cookie -> Maybe Cookie
 findCookie k cookies = find (matchCookie) cookies

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -19,13 +19,10 @@ import Test.Unit.QuickCheck (quickCheck)
 import Test.QuickCheck (Result(..))
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Test.QuickCheck.Gen (Gen, arrayOf1, oneOf)
--- import Test.QuickCheck (quickCheck)
+
 
 
 data CookieSample = CookieSample String String
-
-newtype CookieKey = CookieKey String
-newtype CookieVal = CookieVal String
 
 instance arbitraryCookieSample :: Arbitrary CookieSample where
   arbitrary = CookieSample
@@ -43,11 +40,10 @@ instance arbitraryCookieSample :: Arbitrary CookieSample where
       valRFC2625 =
         oneOf $ genAlpha :|
         ([genAlpha, genDigitChar]
-         <> (pure
-             <$> ['!', '#', '$', '%', '&', '\'', '(', ')'
-             , '*', '+', '-', '.', '/', ':', '<', '='
-             , '>', '?', '@', '[', ']', '^', '_', '`'
-             , '{', '|', '}', '~']))
+         <> (pure <$> ['!', '#', '$', '%', '&', '\'', '(', ')'
+                      , '*', '+', '-', '.', '/', ':', '<', '='
+                      , '>', '?', '@', '[', ']', '^', '_', '`'
+                      , '{', '|', '}', '~']))
 
 main :: Effect Unit
 main = runTest do

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,13 +1,70 @@
 module Test.Main where
 
 import Prelude
-import Effect (Effect)
-import Test.Unit (suite)
-import Test.Unit.Main (runTest)
+
 import Browser.Cookies.DataSpec as DataSpec
+import Browser.Cookies.Internal (bakeCookies)
+
+import Data.Array as Array
+import Data.Char.Gen (genAlpha, genDigitChar)
+import Data.NonEmpty ((:|))
+import Data.String as String
+import Data.String.CodeUnits as SCU
+
+import Effect (Effect)
+
+import Test.Unit (suite, test)
+import Test.Unit.Main (runTest)
+import Test.Unit.QuickCheck (quickCheck)
+import Test.QuickCheck (Result(..))
+import Test.QuickCheck.Arbitrary (class Arbitrary)
+import Test.QuickCheck.Gen (Gen, arrayOf1, oneOf)
+-- import Test.QuickCheck (quickCheck)
+
+
+data CookieSample = CookieSample String String
+
+newtype CookieKey = CookieKey String
+newtype CookieVal = CookieVal String
+
+instance arbitraryCookieSample :: Arbitrary CookieSample where
+  arbitrary = CookieSample
+              <$> ((SCU.fromCharArray <<< Array.fromFoldable)
+                   <$> arrayOf1 keyRFC2625)
+              <*> ((SCU.fromCharArray <<< Array.fromFoldable)
+                   <$> arrayOf1 valRFC2625)
+    where
+      keyRFC2625 =
+        oneOf $ genAlpha :|
+        ([genAlpha, genDigitChar]
+         <> (pure <$> ['!', '#', '$', '%', '&', '\''
+                      , '*', '+', '-', '.', '^', '_'
+                      , '`', '|', '~']))
+      valRFC2625 =
+        oneOf $ genAlpha :|
+        ([genAlpha, genDigitChar]
+         <> (pure
+             <$> ['!', '#', '$', '%', '&', '\'', '(', ')'
+             , '*', '+', '-', '.', '/', ':', '<', '='
+             , '>', '?', '@', '[', ']', '^', '_', '`'
+             , '{', '|', '}', '~']))
 
 main :: Effect Unit
 main = runTest do
   suite "Cookies" do
     DataSpec.encodingTests
-    
+  test "bakeCookies" do
+    quickCheck prop_bakeCookies
+  
+prop_bakeCookies :: Array CookieSample -> Result
+prop_bakeCookies cs =
+  let cs' = String.joinWith ";" $ map combine cs
+      sampleCount = Array.length cs
+      bakeCount = Array.length (bakeCookies cs')
+  in if bakeCount == sampleCount
+     then Success
+     else Failed $
+          "Sample Count: " <> show sampleCount <> "\nBake Count: " <> show bakeCount
+          <> "\n" <> cs'
+  where
+    combine (CookieSample k v) = k <> "=" <> v


### PR DESCRIPTION
As I mentioned in my earlier [comment](https://github.com/vilu/purescript-browser-cookies/issues/1#issue-397222551), I've modified `bakeCookies` to handle the allowed values in [RFC6265](http://www.rfc-editor.org/rfc/rfc6265.txt) . 

I've added a test as well reflect the new functionality.